### PR TITLE
Implement the top of bar on the additional screen

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/screen/AddItemScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/screen/AddItemScreen.kt
@@ -1,0 +1,48 @@
+package com.example.mokumokusolo.ui.screen
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddItemScreen(modifier: Modifier = Modifier) {
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text(text = "追加") },
+                navigationIcon = {
+                    IconButton(onClick = {}) {
+                        Icon(
+                            imageVector = Icons.Default.Close,
+                            contentDescription = "Close"
+                        )
+                    }
+                }
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier.padding(paddingValues)
+        ) {
+        }
+    }
+}
+
+@Preview
+@Composable
+fun AddItemScreenPreview() {
+    AddItemScreen()
+}


### PR DESCRIPTION
## 追加内容
```AddItemScreen.kt```を作成し、画面の最上部に中央揃えのバーを表示するために```CenterAlignedTopAppBar```を定義。

## 追加理由
メイン画面(```HomeScreen.kt```)のFABボタンを押した時にユーザーがアプリもしくは支出を登録できるようにするため。