### PR TITLE
 Implementation of screen transitions when pressing the FAB button

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/screen/AddItemScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/screen/AddItemScreen.kt
@@ -1,30 +1,38 @@
 package com.example.mokumokusolo.ui.screen
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Button
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun AddItemScreen(modifier: Modifier = Modifier) {
+fun AddItemScreen(
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier
+) {
     Scaffold(
         modifier = modifier.fillMaxSize(),
         topBar = {
             CenterAlignedTopAppBar(
                 title = { Text(text = "追加") },
                 navigationIcon = {
-                    IconButton(onClick = {}) {
+                    IconButton(onClick = onClose) {
                         Icon(
                             imageVector = Icons.Default.Close,
                             contentDescription = "Close"
@@ -35,8 +43,27 @@ fun AddItemScreen(modifier: Modifier = Modifier) {
         }
     ) { paddingValues ->
         Column(
-            modifier = Modifier.padding(paddingValues)
+            modifier = Modifier
+                .padding(paddingValues)
+                .fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
+            TextField(
+                value = "",
+                onValueChange = {},
+                label = { Text(text = "アプリ名") },
+                placeholder = { Text(text = "MokuMokuSolo") }
+            )
+            Spacer(modifier = Modifier.padding(8.dp))
+            TextField(
+                value = "",
+                onValueChange = {},
+                label = { Text(text = "現在の収益(月)") },
+            )
+            Spacer(modifier = Modifier.padding(8.dp))
+            Button(onClick = {}) {
+                Text("登録")
+            }
         }
     }
 }
@@ -44,5 +71,5 @@ fun AddItemScreen(modifier: Modifier = Modifier) {
 @Preview
 @Composable
 fun AddItemScreenPreview() {
-    AddItemScreen()
+    AddItemScreen(onClose = {})
 }

--- a/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/screen/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/screen/HomeScreen.kt
@@ -32,6 +32,7 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 @Composable
 fun HomeScreen(modifier: Modifier = Modifier) {
     var selectedChip by remember { mutableStateOf("all") }
+    var showAddItemScreen by remember { mutableStateOf(false) }
     val sampleApps = listOf(
         App(
             id = 1,
@@ -70,63 +71,68 @@ fun HomeScreen(modifier: Modifier = Modifier) {
         )
     )
 
-    Scaffold(
-        modifier = modifier
-            .fillMaxSize()
-            .background(MaterialTheme.colorScheme.background),
-        floatingActionButton = {
-            FloatingActionButton(
-                onClick = {},
-                containerColor = MaterialTheme.colorScheme.primaryContainer
-            ) {
-                Icon(Icons.Default.Add, "")
+    if (showAddItemScreen) {
+        AddItemScreen(
+            onClose = { showAddItemScreen = false }
+        )
+    } else {
+        Scaffold(
+            modifier = modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background),
+            floatingActionButton = {
+                FloatingActionButton(
+                    onClick = { showAddItemScreen = true },
+                    containerColor = MaterialTheme.colorScheme.primaryContainer
+                ) {
+                    Icon(Icons.Default.Add, "")
+                }
             }
-        }
-    ) { paddingValues ->
-        Column(
-            modifier = Modifier
-                .padding(paddingValues)
-                .padding(top = 16.dp)
-                .fillMaxWidth(),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            HomeCards()
-            Row(
-                horizontalArrangement = Arrangement.SpaceAround,
-                modifier = Modifier.padding(top = 16.dp)
+        ) { paddingValues ->
+            Column(
+                modifier = Modifier
+                    .padding(paddingValues)
+                    .padding(top = 16.dp)
+                    .fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                AllChip(
-                    selected = selectedChip == "all",
-                    onClicked = { selectedChip = "all" }
-                )
-                AppsChip(
-                    selected = selectedChip == "apps",
-                    onClicked = { selectedChip = "apps" }
-                )
-                ExpenditureChip(
-                    selected = selectedChip == "expenditure",
-                    onClicked = { selectedChip = "expenditure" }
-                )
-            }
-
-            when (selectedChip) {
-                "all" -> {
-                    AppList(
-                        appList = sampleApps,
-                        modifier = Modifier.width(300.dp)
+                HomeCards()
+                Row(
+                    horizontalArrangement = Arrangement.SpaceAround,
+                    modifier = Modifier.padding(top = 16.dp)
+                ) {
+                    AllChip(
+                        selected = selectedChip == "all",
+                        onClicked = { selectedChip = "all" }
                     )
-                    ExpenditureList(
+                    AppsChip(
+                        selected = selectedChip == "apps",
+                        onClicked = { selectedChip = "apps" }
+                    )
+                    ExpenditureChip(
+                        selected = selectedChip == "expenditure",
+                        onClicked = { selectedChip = "expenditure" }
+                    )
+                }
+                when (selectedChip) {
+                    "all" -> {
+                        AppList(
+                            appList = sampleApps,
+                            modifier = Modifier.width(300.dp)
+                        )
+                        ExpenditureList(
+                            expenditureList = sampleExpenditures
+                        )
+                    }
+
+                    "apps" -> AppList(
+                        appList = sampleApps,
+                    )
+
+                    "expenditure" -> ExpenditureList(
                         expenditureList = sampleExpenditures
                     )
                 }
-
-                "apps" -> AppList(
-                    appList = sampleApps,
-                )
-
-                "expenditure" -> ExpenditureList(
-                    expenditureList = sampleExpenditures
-                )
             }
         }
     }


### PR DESCRIPTION
## 追加内容
1. 追加画面(```AddItemScreen.kt```)にアプリデータ入力用の```TextField```と登録ボタン用の```Button```を実装。
2. メイン画面(```HomeScreen.kt```)のFABボタンを押した時に追加画面(```AddItemScreen.kt```)に遷移するためのフラグを定義し、```if-else```で分岐。
3. 追加画面(```AddItemScreen.kt```)で```navigationIcon```を押した時にメイン画面(```HomeScreen.kt```)に戻る実装。

## 追加理由
メイン画面(```HomeScreen.kt```)と追加画面(```AddItemScreen.kt```)と連携するため。