### PR TITLE
 Add a segment button

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/screen/AddItemScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/screen/AddItemScreen.kt
@@ -3,6 +3,7 @@ package com.example.mokumokusolo.ui.screen
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
@@ -48,6 +49,8 @@ fun AddItemScreen(
                 .fillMaxSize(),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
+            SingleChoiceSegmentedButton()
+            Spacer(modifier = Modifier.height(16.dp))
             TextField(
                 value = "",
                 onValueChange = {},

--- a/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/screen/SingleChoiceSegmentButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/screen/SingleChoiceSegmentButton.kt
@@ -1,0 +1,43 @@
+package com.example.mokumokusolo.ui.screen
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@Composable
+fun SingleChoiceSegmentedButton(modifier: Modifier = Modifier) {
+    var selectedIndex by remember { mutableIntStateOf(0) }
+    val options = listOf("収益", "支出")
+
+    SingleChoiceSegmentedButtonRow(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 48.dp)
+    ) {
+        options.forEachIndexed { index, label ->
+            SegmentedButton(
+                shape = RoundedCornerShape(4.dp),
+                onClick = { selectedIndex = index },
+                selected = index == selectedIndex,
+                label = { Text(label) }
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun SingleChoiceSegmentedButtonPreview() {
+    SingleChoiceSegmentedButton()
+}


### PR DESCRIPTION
## 追加内容
追加画面(```AddItemScreen.kt```)にセグメントボタン(```SingleChoiceSegmentedButton```)を配置。

## 追加理由
アプリ(収益)データを入力するか支出データを入力するのかをユーザーが選択できるようにするため。