### PR TITLE
 Split packages per screen

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/App.kt
@@ -1,7 +1,7 @@
 package com.example.mokumokusolo
 
 import androidx.compose.runtime.Composable
-import com.example.mokumokusolo.ui.screen.HomeScreen
+import com.example.mokumokusolo.ui.screen.home.HomeScreen
 import com.example.mokumokusolo.ui.theme.MokuMokuSoloTheme
 import org.jetbrains.compose.ui.tooling.preview.Preview
 

--- a/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/screen/addItem/AddItemScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/screen/addItem/AddItemScreen.kt
@@ -1,4 +1,4 @@
-package com.example.mokumokusolo.ui.screen
+package com.example.mokumokusolo.ui.screen.addItem
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer

--- a/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/screen/addItem/SingleChoiceSegmentButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/screen/addItem/SingleChoiceSegmentButton.kt
@@ -1,4 +1,4 @@
-package com.example.mokumokusolo.ui.screen
+package com.example.mokumokusolo.ui.screen.addItem
 
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.background

--- a/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/screen/home/AppList.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/screen/home/AppList.kt
@@ -1,5 +1,6 @@
-package com.example.mokumokusolo.ui.screen
+package com.example.mokumokusolo.ui.screen.home
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -19,56 +20,57 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.example.mokumokusolo.model.Expenditure
+import com.example.mokumokusolo.model.App
 import com.example.mokumokusolo.ui.theme.MokuMokuSoloTheme
+import mokumokusolo.composeapp.generated.resources.Res
+import mokumokusolo.composeapp.generated.resources.duolingo
+import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
-fun ExpenditureList(
-    expenditureList: List<Expenditure>,
-    modifier: Modifier = Modifier
-) {
+fun AppList(appList: List<App>, modifier: Modifier = Modifier) {
     LazyColumn(
         modifier = modifier
     ) {
-        items(expenditureList) { expenditure ->
-            ExpenditureListItem(expenditure)
+        items(appList) { app ->
+            AppListItem(app)
         }
     }
 }
 
 @Preview
 @Composable
-fun ExpenditureListPreview() {
+private fun AppListPreview() {
     MokuMokuSoloTheme {
-        val sampleExpenditures = listOf(
-            Expenditure(
+        val sampleApps = listOf(
+            App(
                 id = 1,
-                name = "Netflix",
-                amount = 780.0
+                name = "Duolingo",
+                image = painterResource(Res.drawable.duolingo),
+                revenue = 1000.0
             ),
-            Expenditure(
+            App(
                 id = 2,
-                name = "Amazon Prime",
-                amount = 600.0
+                name = "Duolingo2",
+                image = painterResource(Res.drawable.duolingo),
+                revenue = 1500.0
             ),
-            Expenditure(
+            App(
                 id = 3,
-                name = "Spotify",
-                amount = 1080.0
+                name = "Duolingo3",
+                image = painterResource(Res.drawable.duolingo),
+                revenue = 2000.0
             )
         )
-        ExpenditureList(
-            expenditureList = sampleExpenditures
+        AppList(
+            appList = sampleApps
         )
     }
 }
 
+
 @Composable
-fun ExpenditureListItem(
-    expenditure: Expenditure,
-    modifier: Modifier = Modifier
-) {
+fun AppListItem(app: App, modifier: Modifier = Modifier) {
     ElevatedCard(
         modifier = modifier
             .width(300.dp)
@@ -81,20 +83,27 @@ fun ExpenditureListItem(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(vertical = 8.dp, horizontal = 16.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalAlignment = Alignment.CenterVertically
+                .padding(horizontal = 8.dp, vertical = 16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
+            Image(
+                painter = painterResource(Res.drawable.duolingo),
+                contentDescription = "",
+                modifier = Modifier
+                    .width(40.dp)
+            )
             Text(
-                text = expenditure.name,
+                text = app.name,
                 modifier = Modifier.weight(1f),
                 fontSize = 16.sp,
                 fontWeight = FontWeight.Normal,
                 style = MaterialTheme.typography.bodySmall
             )
             Text(
-                text = "¥${expenditure.amount}",
+                text = "¥${app.revenue}",
                 color = Color.Gray,
+                fontSize = 16.sp,
                 style = MaterialTheme.typography.bodySmall
             )
         }
@@ -103,13 +112,14 @@ fun ExpenditureListItem(
 
 @Preview
 @Composable
-private fun ExpenditureListItemPreview() {
+fun AppListItemPreview() {
     MokuMokuSoloTheme {
-        ExpenditureListItem(
-            expenditure = Expenditure(
+        AppListItem(
+            app = App(
                 id = 1,
-                name = "Netflix",
-                amount = 1000.0
+                name = "Duolingo",
+                image = painterResource(Res.drawable.duolingo),
+                revenue = 1000.0
             )
         )
     }

--- a/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/screen/home/Chips.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/screen/home/Chips.kt
@@ -1,4 +1,4 @@
-package com.example.mokumokusolo.ui.screen
+package com.example.mokumokusolo.ui.screen.home
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
@@ -91,11 +91,11 @@ fun ChipsPreview() {
         ) {
             AllChip(
                 selected = selectedChip == "all",
-                onClicked = { selectedChip = "all"}
+                onClicked = { selectedChip = "all" }
             )
             AppsChip(
                 selected = selectedChip == "apps",
-                onClicked = { selectedChip = "apps"}
+                onClicked = { selectedChip = "apps" }
             )
             ExpenditureChip(
                 selected = selectedChip == "expenditures",

--- a/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/screen/home/ExpenditureList.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/screen/home/ExpenditureList.kt
@@ -1,6 +1,5 @@
-package com.example.mokumokusolo.ui.screen
+package com.example.mokumokusolo.ui.screen.home
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -20,57 +19,56 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.example.mokumokusolo.model.App
+import com.example.mokumokusolo.model.Expenditure
 import com.example.mokumokusolo.ui.theme.MokuMokuSoloTheme
-import mokumokusolo.composeapp.generated.resources.Res
-import mokumokusolo.composeapp.generated.resources.duolingo
-import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
-fun AppList(appList: List<App>, modifier: Modifier = Modifier) {
+fun ExpenditureList(
+    expenditureList: List<Expenditure>,
+    modifier: Modifier = Modifier
+) {
     LazyColumn(
         modifier = modifier
     ) {
-        items(appList) { app ->
-            AppListItem(app)
+        items(expenditureList) { expenditure ->
+            ExpenditureListItem(expenditure)
         }
     }
 }
 
 @Preview
 @Composable
-private fun AppListPreview() {
+fun ExpenditureListPreview() {
     MokuMokuSoloTheme {
-        val sampleApps = listOf(
-            App(
+        val sampleExpenditures = listOf(
+            Expenditure(
                 id = 1,
-                name = "Duolingo",
-                image = painterResource(Res.drawable.duolingo),
-                revenue = 1000.0
+                name = "Netflix",
+                amount = 780.0
             ),
-            App(
+            Expenditure(
                 id = 2,
-                name = "Duolingo2",
-                image = painterResource(Res.drawable.duolingo),
-                revenue = 1500.0
+                name = "Amazon Prime",
+                amount = 600.0
             ),
-            App(
+            Expenditure(
                 id = 3,
-                name = "Duolingo3",
-                image = painterResource(Res.drawable.duolingo),
-                revenue = 2000.0
+                name = "Spotify",
+                amount = 1080.0
             )
         )
-        AppList(
-            appList = sampleApps
+        ExpenditureList(
+            expenditureList = sampleExpenditures
         )
     }
 }
 
-
 @Composable
-fun AppListItem(app: App, modifier: Modifier = Modifier) {
+fun ExpenditureListItem(
+    expenditure: Expenditure,
+    modifier: Modifier = Modifier
+) {
     ElevatedCard(
         modifier = modifier
             .width(300.dp)
@@ -83,27 +81,20 @@ fun AppListItem(app: App, modifier: Modifier = Modifier) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 8.dp, vertical = 16.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                .padding(vertical = 8.dp, horizontal = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically
         ) {
-            Image(
-                painter = painterResource(Res.drawable.duolingo),
-                contentDescription = "",
-                modifier = Modifier
-                    .width(40.dp)
-            )
             Text(
-                text = app.name,
+                text = expenditure.name,
                 modifier = Modifier.weight(1f),
                 fontSize = 16.sp,
                 fontWeight = FontWeight.Normal,
                 style = MaterialTheme.typography.bodySmall
             )
             Text(
-                text = "¥${app.revenue}",
+                text = "¥${expenditure.amount}",
                 color = Color.Gray,
-                fontSize = 16.sp,
                 style = MaterialTheme.typography.bodySmall
             )
         }
@@ -112,14 +103,13 @@ fun AppListItem(app: App, modifier: Modifier = Modifier) {
 
 @Preview
 @Composable
-fun AppListItemPreview() {
+private fun ExpenditureListItemPreview() {
     MokuMokuSoloTheme {
-        AppListItem(
-            app = App(
+        ExpenditureListItem(
+            expenditure = Expenditure(
                 id = 1,
-                name = "Duolingo",
-                image = painterResource(Res.drawable.duolingo),
-                revenue = 1000.0
+                name = "Netflix",
+                amount = 1000.0
             )
         )
     }

--- a/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/screen/home/HomeCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/screen/home/HomeCards.kt
@@ -1,4 +1,4 @@
-package com.example.mokumokusolo.ui.screen
+package com.example.mokumokusolo.ui.screen.home
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box

--- a/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/screen/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/screen/home/HomeScreen.kt
@@ -1,4 +1,4 @@
-package com.example.mokumokusolo.ui.screen
+package com.example.mokumokusolo.ui.screen.home
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -24,6 +24,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.example.mokumokusolo.model.App
 import com.example.mokumokusolo.model.Expenditure
+import com.example.mokumokusolo.ui.screen.addItem.AddItemScreen
 import mokumokusolo.composeapp.generated.resources.Res
 import mokumokusolo.composeapp.generated.resources.duolingo
 import org.jetbrains.compose.resources.painterResource


### PR DESCRIPTION
## 追加内容
```ui/screen```内に```home```パッケージと```addItem```パッケージを追加。
```home```→メイン画面用パッケージ
```addItem```→追加画面パッケージ

## 追加理由
```ui/screen```内にファイルが複数存在しており、画面ごとにファイルを整理することで可読性を向上させるため。