### PR TITLE
feat: MainViewModel Implementation

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/main/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/main/MainScreen.kt
@@ -12,11 +12,13 @@ import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.compose.NavHost
@@ -32,14 +34,18 @@ import com.example.mokumokusolo.ui.screen.addItem.AddItemScreen
 import com.example.mokumokusolo.ui.screen.home.HomeScreen
 
 @Composable
-fun MainScreen(modifier: Modifier = Modifier) {
+fun MainScreen(
+    modifier: Modifier = Modifier,
+    viewModel: MainViewModel = viewModel()
+) {
     val navController = rememberNavController()
     val currentBackStack by navController.currentBackStackEntryAsState()
     val currentDestination = currentBackStack?.destination
 
+    val apps by viewModel.apps.collectAsState()
+    val expenditures by viewModel.expenditures.collectAsState()
+
     var showAddItemScreen by remember { mutableStateOf(false) }
-    var apps by remember { mutableStateOf(emptyList<App>()) }
-    var expenditures by remember { mutableStateOf(emptyList<Expenditure>()) }
 
     Scaffold(
         modifier = modifier
@@ -113,14 +119,14 @@ fun MainScreen(modifier: Modifier = Modifier) {
                     if (isIncome) {
                         val newApp =
                             App(id = apps.size + 1, name = name, amount = amount.toDouble())
-                        apps = apps + newApp
+                        viewModel.updateApps(newApp)
                     } else {
                         val newExpenditure = Expenditure(
                             id = expenditures.size + 1,
                             name = name,
                             amount = amount.toDouble()
                         )
-                        expenditures = expenditures + newExpenditure
+                        viewModel.updateExpenditures(newExpenditure)
                     }
                     showAddItemScreen = false
                 }

--- a/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/main/MainViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/main/MainViewModel.kt
@@ -1,0 +1,25 @@
+package com.example.mokumokusolo.ui.main
+
+import androidx.lifecycle.ViewModel
+import com.example.mokumokusolo.model.App
+import com.example.mokumokusolo.model.Expenditure
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+
+class MainViewModel : ViewModel() {
+    private val _apps = MutableStateFlow<List<App>>(emptyList())
+    val apps: StateFlow<List<App>> = _apps
+
+    private val _expenditures = MutableStateFlow<List<Expenditure>>(emptyList())
+    val expenditures: StateFlow<List<Expenditure>> = _expenditures
+
+    fun updateApps(newApp: App) {
+        _apps.value = _apps.value + newApp
+    }
+
+    fun updateExpenditures(newExpenditure: Expenditure) {
+        _expenditures.value = _expenditures.value + newExpenditure
+    }
+
+}

--- a/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/screen/home/AppList.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/screen/home/AppList.kt
@@ -88,7 +88,7 @@ fun AppListItem(app: App, modifier: Modifier = Modifier) {
                 style = MaterialTheme.typography.bodySmall
             )
             Text(
-                text = "¥${app.amount}",
+                text = "¥${app.amount.toInt()}",
                 color = Color.Gray,
                 fontSize = 16.sp,
                 style = MaterialTheme.typography.bodySmall

--- a/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/screen/home/ExpenditureList.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/screen/home/ExpenditureList.kt
@@ -93,7 +93,7 @@ fun ExpenditureListItem(
                 style = MaterialTheme.typography.bodySmall
             )
             Text(
-                text = "¥${expenditure.amount}",
+                text = "¥${expenditure.amount.toInt()}",
                 color = Color.Gray,
                 style = MaterialTheme.typography.bodySmall
             )


### PR DESCRIPTION
## MainViewModelの実装

- ```MainScreen```で表示するアプリのリスト(```apps```)と支出のリスト(```expenditures```)が画面回転時に破棄されていた。
- ```ViewModel```を作り、```Flow```を利用して、```MainScreen```(コンポーザブル)は状態を利用することに集中する。