### PR TITLE
refactor: Move home screen to ui/home

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/home/AppList.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/home/AppList.kt
@@ -1,4 +1,4 @@
-package com.example.mokumokusolo.ui.screen.home
+package com.example.mokumokusolo.ui.home
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
@@ -19,56 +19,51 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.example.mokumokusolo.model.Expenditure
+import com.example.mokumokusolo.model.App
 import com.example.mokumokusolo.ui.theme.MokuMokuSoloTheme
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
-fun ExpenditureList(
-    expenditureList: List<Expenditure>,
-    modifier: Modifier = Modifier
-) {
+fun AppList(appList: List<App>, modifier: Modifier = Modifier) {
     LazyColumn(
         modifier = modifier
     ) {
-        items(expenditureList) { expenditure ->
-            ExpenditureListItem(expenditure)
+        items(appList) { app ->
+            AppListItem(app)
         }
     }
 }
 
 @Preview
 @Composable
-fun ExpenditureListPreview() {
+private fun AppListPreview() {
     MokuMokuSoloTheme {
-        val sampleExpenditures = listOf(
-            Expenditure(
+        val sampleApps = listOf(
+            App(
                 id = 1,
-                name = "Netflix",
-                amount = 780.0
+                name = "Duolingo",
+                amount = 1000.0
             ),
-            Expenditure(
+            App(
                 id = 2,
-                name = "Amazon Prime",
-                amount = 600.0
+                name = "Duolingo2",
+                amount = 1500.0
             ),
-            Expenditure(
+            App(
                 id = 3,
-                name = "Spotify",
-                amount = 1080.0
+                name = "Duolingo3",
+                amount = 2000.0
             )
         )
-        ExpenditureList(
-            expenditureList = sampleExpenditures
+        AppList(
+            appList = sampleApps
         )
     }
 }
 
+
 @Composable
-fun ExpenditureListItem(
-    expenditure: Expenditure,
-    modifier: Modifier = Modifier
-) {
+fun AppListItem(app: App, modifier: Modifier = Modifier) {
     ElevatedCard(
         modifier = modifier
             .width(300.dp)
@@ -82,19 +77,20 @@ fun ExpenditureListItem(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 8.dp, vertical = 16.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalAlignment = Alignment.CenterVertically
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             Text(
-                text = expenditure.name,
+                text = app.name,
                 modifier = Modifier.weight(1f),
                 fontSize = 16.sp,
                 fontWeight = FontWeight.Normal,
                 style = MaterialTheme.typography.bodySmall
             )
             Text(
-                text = "¥${expenditure.amount.toInt()}",
+                text = "¥${app.amount.toInt()}",
                 color = Color.Gray,
+                fontSize = 16.sp,
                 style = MaterialTheme.typography.bodySmall
             )
         }
@@ -103,12 +99,12 @@ fun ExpenditureListItem(
 
 @Preview
 @Composable
-private fun ExpenditureListItemPreview() {
+fun AppListItemPreview() {
     MokuMokuSoloTheme {
-        ExpenditureListItem(
-            expenditure = Expenditure(
+        AppListItem(
+            app = App(
                 id = 1,
-                name = "Netflix",
+                name = "Duolingo",
                 amount = 1000.0
             )
         )

--- a/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/home/Chips.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/home/Chips.kt
@@ -1,4 +1,4 @@
-package com.example.mokumokusolo.ui.screen.home
+package com.example.mokumokusolo.ui.home
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row

--- a/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/home/ExpenditureList.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/home/ExpenditureList.kt
@@ -1,4 +1,4 @@
-package com.example.mokumokusolo.ui.screen.home
+package com.example.mokumokusolo.ui.home
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
@@ -19,51 +19,56 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.example.mokumokusolo.model.App
+import com.example.mokumokusolo.model.Expenditure
 import com.example.mokumokusolo.ui.theme.MokuMokuSoloTheme
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
-fun AppList(appList: List<App>, modifier: Modifier = Modifier) {
+fun ExpenditureList(
+    expenditureList: List<Expenditure>,
+    modifier: Modifier = Modifier
+) {
     LazyColumn(
         modifier = modifier
     ) {
-        items(appList) { app ->
-            AppListItem(app)
+        items(expenditureList) { expenditure ->
+            ExpenditureListItem(expenditure)
         }
     }
 }
 
 @Preview
 @Composable
-private fun AppListPreview() {
+fun ExpenditureListPreview() {
     MokuMokuSoloTheme {
-        val sampleApps = listOf(
-            App(
+        val sampleExpenditures = listOf(
+            Expenditure(
                 id = 1,
-                name = "Duolingo",
-                amount = 1000.0
+                name = "Netflix",
+                amount = 780.0
             ),
-            App(
+            Expenditure(
                 id = 2,
-                name = "Duolingo2",
-                amount = 1500.0
+                name = "Amazon Prime",
+                amount = 600.0
             ),
-            App(
+            Expenditure(
                 id = 3,
-                name = "Duolingo3",
-                amount = 2000.0
+                name = "Spotify",
+                amount = 1080.0
             )
         )
-        AppList(
-            appList = sampleApps
+        ExpenditureList(
+            expenditureList = sampleExpenditures
         )
     }
 }
 
-
 @Composable
-fun AppListItem(app: App, modifier: Modifier = Modifier) {
+fun ExpenditureListItem(
+    expenditure: Expenditure,
+    modifier: Modifier = Modifier
+) {
     ElevatedCard(
         modifier = modifier
             .width(300.dp)
@@ -77,20 +82,19 @@ fun AppListItem(app: App, modifier: Modifier = Modifier) {
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 8.dp, vertical = 16.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
-                text = app.name,
+                text = expenditure.name,
                 modifier = Modifier.weight(1f),
                 fontSize = 16.sp,
                 fontWeight = FontWeight.Normal,
                 style = MaterialTheme.typography.bodySmall
             )
             Text(
-                text = "¥${app.amount.toInt()}",
+                text = "¥${expenditure.amount.toInt()}",
                 color = Color.Gray,
-                fontSize = 16.sp,
                 style = MaterialTheme.typography.bodySmall
             )
         }
@@ -99,12 +103,12 @@ fun AppListItem(app: App, modifier: Modifier = Modifier) {
 
 @Preview
 @Composable
-fun AppListItemPreview() {
+private fun ExpenditureListItemPreview() {
     MokuMokuSoloTheme {
-        AppListItem(
-            app = App(
+        ExpenditureListItem(
+            expenditure = Expenditure(
                 id = 1,
-                name = "Duolingo",
+                name = "Netflix",
                 amount = 1000.0
             )
         )

--- a/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/home/HomeCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/home/HomeCards.kt
@@ -1,4 +1,4 @@
-package com.example.mokumokusolo.ui.screen.home
+package com.example.mokumokusolo.ui.home
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box

--- a/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/home/HomeCardsUiState.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/home/HomeCardsUiState.kt
@@ -1,4 +1,4 @@
-package com.example.mokumokusolo.ui.screen.home
+package com.example.mokumokusolo.ui.home
 
 import com.example.mokumokusolo.model.App
 import com.example.mokumokusolo.model.Expenditure

--- a/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/home/HomeScreen.kt
@@ -1,4 +1,4 @@
-package com.example.mokumokusolo.ui.screen.home
+package com.example.mokumokusolo.ui.home
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column

--- a/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/main/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/main/MainScreen.kt
@@ -30,8 +30,8 @@ import com.example.mokumokusolo.model.App
 import com.example.mokumokusolo.model.Expenditure
 import com.example.mokumokusolo.navigation.AppDestination
 import com.example.mokumokusolo.navigation.bottomNavItems
+import com.example.mokumokusolo.ui.home.HomeScreen
 import com.example.mokumokusolo.ui.screen.addItem.AddItemScreen
-import com.example.mokumokusolo.ui.screen.home.HomeScreen
 
 @Composable
 fun MainScreen(


### PR DESCRIPTION
## 作業内容
ホーム画面の管理する場所を```ui/screen/home```から```ui/home```に変更

## 変更理由
メイン画面である```main```パッケージを```ui/main```で管理しているのに、ホーム画面は```ui/screen/home```と統一されておらず、保守性が低いと考えたため。