### PR TITLE
fix/unify-list-item

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/home/ExpenditureList.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/home/ExpenditureList.kt
@@ -95,6 +95,7 @@ fun ExpenditureListItem(
             Text(
                 text = "¥${expenditure.amount.toInt()}",
                 color = Color.Gray,
+                fontSize = 16.sp,
                 style = MaterialTheme.typography.bodySmall
             )
         }


### PR DESCRIPTION
## 概要：リストアイテムのレイアウトを統一する調整

リストアイテムであるアプリのリストアイテム(```AppListItem```)と支出のリストアイテム(```ExpenditureListItem```)のフォントサイズが異なっていたので、```fontSize = 16.dp```を指定した。